### PR TITLE
Fix Personal Vehicle Blips and Exclusive Driver

### DIFF
--- a/vMenu/menus/PersonalVehicle.cs
+++ b/vMenu/menus/PersonalVehicle.cs
@@ -192,12 +192,10 @@ namespace vMenuClient
                         {
                             if (_checked)
                             {
-                                SetVehicleExclusiveDriver(CurrentPersonalVehicle.Handle, Game.PlayerPed.Handle, 1);
                                 SetVehicleExclusiveDriver_2(CurrentPersonalVehicle.Handle, Game.PlayerPed.Handle, 1);
                             }
                             else
                             {
-                                SetVehicleExclusiveDriver(CurrentPersonalVehicle.Handle, 0, 1);
                                 SetVehicleExclusiveDriver_2(CurrentPersonalVehicle.Handle, 0, 1);
                             }
                         }


### PR DESCRIPTION
This change removes a `API` function call that would invalidate the entire delegate function. The function in question removed had parameters changed in a [recent update](https://github.com/citizenfx/natives/blame/master/VEHICLE/SetVehicleExclusiveDriver.md), which caused an exception to be thrown when `OnCheckboxChanged` was called from MenuAPI.